### PR TITLE
Fix CGImageRef leak when loading image from buffer view

### DIFF
--- a/GLTFKit2/GLTFKit2/GLTFAsset.m
+++ b/GLTFKit2/GLTFKit2/GLTFAsset.m
@@ -354,7 +354,9 @@ int GLTFComponentCountForDimension(GLTFValueDimension dim) {
         imageSource = CGImageSourceCreateWithURL((__bridge CFURLRef)_uri, NULL);
     }
     if (imageSource) {
-        return CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
+        CGImageRef image = CGImageSourceCreateImageAtIndex(imageSource, 0, NULL);
+        CFRelease(imageSource);
+        return image;
     }
     return NULL;
 }

--- a/GLTFKit2/GLTFKit2/GLTFModelIO.m
+++ b/GLTFKit2/GLTFKit2/GLTFModelIO.m
@@ -276,6 +276,7 @@ static NSString *GLTFMDLVertexAttributeNameForSemantic(NSString *name) {
                                              channelCount:4
                                           channelEncoding:MDLTextureChannelEncodingUInt8
                                                    isCube:NO];
+            CFRelease(cgImage);
         }
         texturesForImageIdenfiers[image.identifier] = mdlTexture;
     }

--- a/GLTFKit2/GLTFKit2/GLTFSceneKit.m
+++ b/GLTFKit2/GLTFKit2/GLTFSceneKit.m
@@ -244,6 +244,7 @@ static NSArray<NSValue *> *GLTFMatrixValueArrayFromAccessor(GLTFAccessor *access
         } else {
             CGImageRef cgImage = [image createCGImage];
             uiImage = [[NSUIImage alloc] initWithCGImage:cgImage size:NSZeroSize];
+            CFRelease(cgImage);
         }
         imagesForIdentfiers[image.identifier] = uiImage;
     }


### PR DESCRIPTION
Two modifications were made locally to create an environment appropriate for leak testing. First, the `GLTFDocument`'s `asset` property was removed to eliminate one reference. Second, the `SCNView`'s `scene` was cleared along with the `asset` four seconds after the view loaded:

```swift
Timer.scheduledTimer(withTimeInterval: 4.0, repeats: false) { _ in
    self.scnView.scene = nil
    self.asset = nil
}
```

Here's the before and after in Instruments when loading [DamagedHelmet.glb](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/DamagedHelmet/glTF-Binary):

<img width="365" alt="allocations-before" src="https://user-images.githubusercontent.com/7120397/109254019-58a2a100-77ae-11eb-9f96-81d85bbd9617.png">
<img width="370" alt="allocations-after" src="https://user-images.githubusercontent.com/7120397/109254021-5b04fb00-77ae-11eb-9467-ba7bfe8dee74.png">

I considered an alternative approach where the `createCGImage` helper method returned an `NSUIImage` so the caller doesn't need to clean up with `CFRelease`. However, it looks like `CGImageRef` may be preferred as a cross-platform image type for this code base. If that isn't the case, happy to resubmit with `NSUIImage` implementation.