### PR TITLE
Filter out nil meshDescriptors

### DIFF
--- a/GLTFKit2/GLTFKit2/GLTFRealityKit.swift
+++ b/GLTFKit2/GLTFKit2/GLTFRealityKit.swift
@@ -279,7 +279,9 @@ public class GLTFRealityKitLoader {
     }
 
     func convert(mesh gltfMesh: GLTFMesh, context: GLTFRealityKitResourceContext) throws -> RealityKit.ModelComponent {
-        let meshDescriptors = try gltfMesh.primitives.map { try self.convert(primitive: $0, context:context)! }
+        let meshDescriptors = try gltfMesh.primitives.map { try self.convert(primitive: $0, context:context) }
+            .filter({$0 != nil})
+            .map({$0!})
 
         let meshResource = try MeshResource.generate(from: meshDescriptors)
 


### PR DESCRIPTION
Not all primitive types are currently supported, this filters out those that are not handled.