### PR TITLE
Set SCNMaterial.name to GLTFMaterial.name

### DIFF
--- a/GLTFKit2/GLTFKit2/GLTFSceneKit.m
+++ b/GLTFKit2/GLTFKit2/GLTFSceneKit.m
@@ -840,6 +840,7 @@ static float GLTFLuminanceFromRGBA(simd_float4 rgba) {
                 }
             }
         }
+        scnMaterial.name = material.name;
         scnMaterial.doubleSided = material.isDoubleSided;
         scnMaterial.blendMode = (material.alphaMode == GLTFAlphaModeBlend) ? SCNBlendModeAlpha : SCNBlendModeReplace;
         scnMaterial.transparencyMode = (material.alphaMode == GLTFAlphaModeBlend) ? SCNTransparencyModeDualLayer : SCNTransparencyModeDefault;


### PR DESCRIPTION
The name of `SCNMaterial` was never set before

Thanks for a really good framework and all the work that's been put into it!👏