### PR TITLE
Fixed file type associations on macOS 12 Monterey

### DIFF
--- a/GLTFViewer/QuickLook/Info.plist
+++ b/GLTFViewer/QuickLook/Info.plist
@@ -12,6 +12,8 @@
 			<array>
 				<string>public.gltf</string>
 				<string>public.glb</string>
+				<string>org.khronos.gltf</string>
+				<string>org.khronos.glb</string>
 			</array>
 			<key>QLSupportsSearchableItems</key>
 			<false/>

--- a/GLTFViewer/macOS/Info.plist
+++ b/GLTFViewer/macOS/Info.plist
@@ -27,6 +27,7 @@
 			<string>Default</string>
 			<key>LSItemContentTypes</key>
 			<array>
+				<string>public.gltf</string>
 				<string>org.khronos.gltf</string>
 			</array>
 			<key>LSTypeIsPackage</key>
@@ -56,6 +57,7 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>org.khronos.glb</string>
+				<string>public.glb</string>
 			</array>
 			<key>LSTypeIsPackage</key>
 			<integer>0</integer>
@@ -89,6 +91,62 @@
 	<string>NSApplication</string>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>GL Transmission Format</string>
+			<key>UTTypeIconFile</key>
+			<string></string>
+			<key>UTTypeIcons</key>
+			<dict>
+				<key>UTTypeIconBadgeName</key>
+				<string>document-icon</string>
+				<key>UTTypeIconText</key>
+				<string>GLTF</string>
+			</dict>
+			<key>UTTypeIdentifier</key>
+			<string>public.gltf</string>
+			<key>UTTypeReferenceURL</key>
+			<string>https://www.khronos.org/gltf/</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>gltf</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>GL Transmission Format (Binary)</string>
+			<key>UTTypeIconFile</key>
+			<string></string>
+			<key>UTTypeIcons</key>
+			<dict>
+				<key>UTTypeIconBadgeName</key>
+				<string>document-icon</string>
+				<key>UTTypeIconText</key>
+				<string>GLB</string>
+			</dict>
+			<key>UTTypeIdentifier</key>
+			<string>public.glb</string>
+			<key>UTTypeReferenceURL</key>
+			<string>https://www.khronos.org/gltf/</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>glb</string>
+				</array>
+			</dict>
+		</dict>
 		<dict>
 			<key>UTTypeConformsTo</key>
 			<array>


### PR DESCRIPTION
In order for .gltf and .glb files to be recognized on older operating systems that use obsolete UTIs like `public.gltf`, we now include both `public.`- and `org.khronos.`- prefixed UTIs as document/imported file types in the macOS sample viewer and QuickLook plugin. This workaround will eventually go away after we drop support for macOS 12 and 13 in the 0.6.x series of releases.